### PR TITLE
fix(types): import `Authflow` from `prismarine-auth`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,6 @@
 /// <reference types="node" />
+import { Authflow } from "prismarine-auth";
+
 declare module 'prismarine-realms' {
   export class RealmAPI {
     /**


### PR DESCRIPTION
Import `Authflow` from `prismarine-auth` to prevent errors in typescript projects.

Previously an error was thrown:

```
node_modules/prismarine-realms/index.d.ts:9:27 - error TS2304: Cannot find name 'Authflow'.

9     constructor(authflow: Authflow, platform: 'bedrock' | 'java')
                            ~~~~~~~~

node_modules/prismarine-realms/index.d.ts:11:27 - error TS2304: Cannot find name 'Authflow'.

11     static from(authflow: Authflow, platform: 'bedrock' | 'java'): BedrockRealmAPI | JavaRealmAPI
                             ~~~~~~~~


Found 2 errors in the same file, starting at: node_modules/prismarine-realms/index.d.ts:9
```