### PR TITLE
Retry 5xx Errors

### DIFF
--- a/src/bedrock/api.js
+++ b/src/bedrock/api.js
@@ -5,10 +5,7 @@ const Download = require('../structures/Download')
 
 module.exports = class BedrockRealmAPI extends RealmAPI {
   async getRealmAddress (realmId) {
-    // This endpoint on the Realms API can be very intermittent and may fail with error code 503. We retry the request maximum 5 times to help mitigate this
-    const data = await this.rest.get(`/worlds/${realmId}/join`, {
-      retryCount: 5
-    })
+    const data = await this.rest.get(`/worlds/${realmId}/join`)
     const [host, port] = data.address.split(':')
     return { host, port: Number(port) }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ class RealmAPI {
   }
 
   async restoreRealmFromBackup (realmId, backupId) {
-    return await this.rest.put(`/worlds/${realmId}/backups?backupId=${encodeURIComponent(backupId)}&clientSupportsRetries`, { retryCount: 5 })
+    return await this.rest.put(`/worlds/${realmId}/backups?backupId=${encodeURIComponent(backupId)}&clientSupportsRetries`)
   }
 }
 

--- a/src/java/api.js
+++ b/src/java/api.js
@@ -5,7 +5,7 @@ const Download = require('../structures/Download')
 
 module.exports = class JavaRealmAPI extends RealmAPI {
   async getRealmAddress (realmId) {
-    const data = await this.rest.get(`/worlds/v1/${realmId}/join/pc`, { retryCount: 5 })
+    const data = await this.rest.get(`/worlds/v1/${realmId}/join/pc`)
     const [host, port] = data.address.split(':')
     return { host, port: Number(port) }
   }

--- a/src/rest.js
+++ b/src/rest.js
@@ -16,7 +16,7 @@ module.exports = class Rest {
     } else if (platform === 'java') {
       this.getAuth = () => authflow.getMinecraftJavaToken({ fetchProfile: true }).then(formatJavaAuth)
     }
-    this.maxRetries = options.maxRetries ?? 5
+    this.maxRetries = options.maxRetries ?? 4
   }
 
   get (route, options) {

--- a/src/rest.js
+++ b/src/rest.js
@@ -74,7 +74,7 @@ module.exports = class Rest {
       return response.text()
     } else {
       debug('Request fail', response)
-      // Some endpoints on the Realms API can be very intermittent and may fail with error code 503. We retry 5xx errors a maximum of 5 times to help mitigate this
+      // Some endpoints on the Realms API can be very intermittent and may fail with error code 503. We retry 5xx errors a maximum of 4 times to help mitigate this
       if (response.status >= 500 && response.status < 600 && retries < this.maxRetries) {
         const delay = Math.pow(2, retries) * 1000
         debug('retry', retries, 'in', delay, 'ms')


### PR DESCRIPTION
This PR exponentially increases the retry delay and removes the `retryCount` parameter. The exponential increase in retry delay is intended to help mitigate intermittent errors that can occur when using the Realms API. 

The first retry will have a delay of 1 second (2^0 * 1000).
The second retry will have a delay of 2 seconds (2^1 * 1000).
The third retry will have a delay of 4 seconds (2^2 * 1000).
The fourth retry will have a delay of 8 seconds (2^3 * 1000).
The fifth and final retry will have a delay of 16 seconds (2^4 * 1000).