### PR TITLE
fix: use new bedrock endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
-
+        node-version: [16.x, 18.x, 20.x]
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm install
-    - run: npm test
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [20.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "chai-as-promised": "^7.1.1",
     "mocha": "^11.0.1",
     "nock": "^13.2.4",
-    "prismarine-auth": "^2.0.1",
+    "prismarine-auth": "^2.7.0",
     "prismarine-realms": "file:.",
     "standard": "^17.0.0"
   },

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,8 +1,8 @@
 module.exports = {
   bedrock: {
-    host: 'https://bedrock.frontendlegacy.realms.minecraft-services.net/',
+    host: 'https://bedrock.frontendlegacy.realms.minecraft-services.net',
     userAgent: 'MCPE/UWP',
-    relyingParty: 'https://bedrock.frontendlegacy.realms.minecraft-services.net/'
+    relyingParty: 'https://bedrock.frontendlegacy.realms.minecraft-services.net'
   },
   java: {
     host: 'https://pc.realms.minecraft.net',

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,8 +1,8 @@
 module.exports = {
   bedrock: {
-    host: 'https://pocket.realms.minecraft.net',
+    host: 'https://bedrock.frontendlegacy.realms.minecraft-services.net/',
     userAgent: 'MCPE/UWP',
-    relyingParty: 'https://pocket.realms.minecraft.net/'
+    relyingParty: 'https://bedrock.frontendlegacy.realms.minecraft-services.net/'
   },
   java: {
     host: 'https://pc.realms.minecraft.net',

--- a/test/bedrockAPI.js
+++ b/test/bedrockAPI.js
@@ -28,7 +28,7 @@ const authflow = new Authflow()
 
 const api = RealmAPI.from(authflow, 'bedrock', { skipAuth: true })
 
-nock('https://pocket.realms.minecraft.net')
+nock('https://bedrock.frontendlegacy.realms.minecraft-services.net')
   .get('/worlds')
   .reply(200, { servers: [World] })
   .get(`/worlds/${config.realmId}`)

--- a/test/bedrockAPI.js
+++ b/test/bedrockAPI.js
@@ -28,7 +28,7 @@ const authflow = new Authflow()
 
 const api = RealmAPI.from(authflow, 'bedrock', { skipAuth: true })
 
-nock('https://bedrock.frontendlegacy.realms.minecraft-services.net')
+nock('https://pocket.realms.minecraft.net')
   .get('/worlds')
   .reply(200, { servers: [World] })
   .get(`/worlds/${config.realmId}`)


### PR DESCRIPTION
Switch the bedrock endpoint from using https://pocket.realms.minecraft.net/ to https://bedrock.frontendlegacy.realms.minecraft-services.net/

Fixes: #59 