### PR TITLE
"Unknown client version" fix for Realms API

### DIFF
--- a/src/rest.js
+++ b/src/rest.js
@@ -39,7 +39,9 @@ module.exports = class Rest {
     const url = `${this.host}${request.route}`
 
     const headers = {
-      'Client-Version': '0.0.0',
+      // As of Minecraft update 26.13, the "Client-Version" header must be the current version of the game
+      // in the format of 1.x.x, otherwise the Realms API will return an error message of "Unknown client version"
+      'Client-Version': '1.26.13',
       'User-Agent': this.userAgent
     }
 

--- a/src/rest.js
+++ b/src/rest.js
@@ -3,7 +3,7 @@ const fetch = require('node-fetch')
 
 const constants = require('./constants')
 
-const { formatBedrockAuth, formatJavaAuth } = require('./util')
+const { formatBedrockAuth, formatJavaAuth, getBedrockVersion } = require('./util')
 
 module.exports = class Rest {
   constructor (authflow, platform, options) {
@@ -37,11 +37,15 @@ module.exports = class Rest {
 
   async prepareRequest (request) {
     const url = `${this.host}${request.route}`
+    const version = this.options.clientVersion ?? await getBedrockVersion();
+    if (!version.startsWith("1.")) {
+      throw new Error(`Invalid client version ${version}, must be in format 1.x.x`)
+    }
 
     const headers = {
       // As of Minecraft update 26.13, the "Client-Version" header must be the current version of the game
       // in the format of 1.x.x, otherwise the Realms API will return an error message of "Unknown client version"
-      'Client-Version': '1.26.13',
+      'Client-Version': version,
       'User-Agent': this.userAgent
     }
 

--- a/src/rest.js
+++ b/src/rest.js
@@ -37,8 +37,8 @@ module.exports = class Rest {
 
   async prepareRequest (request) {
     const url = `${this.host}${request.route}`
-    const version = this.options.clientVersion ?? await getBedrockVersion();
-    if (!version.startsWith("1.")) {
+    const version = this.options.clientVersion ?? await getBedrockVersion()
+    if (!version.startsWith('1.')) {
       throw new Error(`Invalid client version ${version}, must be in format 1.x.x`)
     }
 

--- a/src/util.js
+++ b/src/util.js
@@ -7,7 +7,18 @@ function formatBedrockAuth (res) {
   return ['authorization', `XBL3.0 x=${res.userHash};${res.XSTSToken}`]
 }
 
+async function getBedrockVersion() {
+  const res = await fetch("https://itunes.apple.com/lookup?bundleId=com.mojang.minecraftpe");
+  const data = await res.json();
+  if (!data.results?.length) {
+    throw new Error("Failed to fetch latest version of Minecraft: Bedrock Edition");
+  }
+  const version = data.results[0].version;
+  return version.startsWith("1.") ? version : `1.${version}`;
+}
+
 module.exports = {
   formatJavaAuth,
-  formatBedrockAuth
+  formatBedrockAuth,
+  getBedrockVersion
 }

--- a/src/util.js
+++ b/src/util.js
@@ -7,14 +7,14 @@ function formatBedrockAuth (res) {
   return ['authorization', `XBL3.0 x=${res.userHash};${res.XSTSToken}`]
 }
 
-async function getBedrockVersion() {
-  const res = await fetch("https://itunes.apple.com/lookup?bundleId=com.mojang.minecraftpe");
-  const data = await res.json();
+async function getBedrockVersion () {
+  const res = await fetch('https://itunes.apple.com/lookup?bundleId=com.mojang.minecraftpe')
+  const data = await res.json()
   if (!data.results?.length) {
-    throw new Error("Failed to fetch latest version of Minecraft: Bedrock Edition");
+    throw new Error('Failed to fetch latest version of Minecraft: Bedrock Edition')
   }
-  const version = data.results[0].version;
-  return version.startsWith("1.") ? version : `1.${version}`;
+  const version = data.results[0].version
+  return version.startsWith('1.') ? version : `1.${version}`
 }
 
 module.exports = {


### PR DESCRIPTION
In 26.13, Minecraft now verifies that the **Client-Version** is the current version of the game in the format of `1.x.x`. If it's not you'll receive an "Unknown client version" header. 

This has been tested by setting the client-version to **26.2**.